### PR TITLE
Make released plugin JDK 8 compatible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,9 +104,9 @@
                         <arg>-feature</arg>
                         <arg>-Xlint:deprecation,infer-any,unused</arg>
                         <arg>-Xfatal-warnings</arg>
-                        <arg>-target:${maven.compiler.release}</arg>
+                        <arg>-target:8</arg>
                         <arg>--release</arg>
-                        <arg>${maven.compiler.release}</arg>
+                        <arg>8</arg>
                     </args>
                 </configuration>
                 <executions>


### PR DESCRIPTION
Allows using Java 11 features in Java test code,
but makes compiled Scala code JDK 8 compatible.
So that the surefire plugin can be used on JDK 8.

https://docs.scala-lang.org/overviews/compiler-options/index.html

https://github.com/janhicken/surefire-scalatest/issues/31